### PR TITLE
Fix compiled views path in wp-admin context

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ define(
 		],
 		'path_to_compiled_views' => __DIR__ . '/wp-content/themes/<your-theme>/dist/blade', // Where you want Blade to save compiled files.
 		'never_expire_cache'     => false, // Use `true` on production environments.
+		'base_path'              => __DIR__, //  The base path that should be removed from paths before hashing.
 	]
 );
 ```

--- a/bin/compile.php
+++ b/bin/compile.php
@@ -15,13 +15,13 @@ $vendor_autoload_file = $options['v'] ?? $options['vendor-autoload-file'] ?? __D
 // Check if a config path was set.
 if ( empty( $config_file ) || ! file_exists( $config_file ) ) {
 	echo "\033[31m✗ Path to config file missing!\n";
-	exit( 0 );
+	exit( 1 );
 }
 
 // Check if vendor autoload file was set.
 if ( empty( $vendor_autoload_file ) || ! file_exists( $vendor_autoload_file ) ) {
 	echo "\033[31m✗ Path to config file missing!\n";
-	exit( 0 );
+	exit( 1 );
 }
 
 // Load files.
@@ -37,6 +37,7 @@ $blade_config                  = get_configuration();
 $blade                         = new Blade();
 $blade->paths_to_views         = $blade_config['paths_to_views'] ?? [];
 $blade->path_to_compiled_views = $blade_config['path_to_compiled_views'] ?? '';
+$blade->base_path              = $blade_config['base_path'] ?? '';
 $blade->initialize();
 
 // Build Blade cache.

--- a/inc/class-blade.php
+++ b/inc/class-blade.php
@@ -48,6 +48,13 @@ class Blade {
 	public string $path_to_compiled_views = '';
 
 	/**
+	 * Store the base path.
+	 *
+	 * @var string Base path.
+	 */
+	public string $base_path = '';
+
+	/**
 	 * Store view factory.
 	 *
 	 * @var ViewFactory View factory.
@@ -93,7 +100,7 @@ class Blade {
 
 		// Create View Factory capable of rendering PHP and Blade templates.
 		$view_resolver        = new EngineResolver();
-		$this->blade_compiler = new BladeCompiler( $filesystem, $this->path_to_compiled_views );
+		$this->blade_compiler = new BladeCompiler( $filesystem, $this->path_to_compiled_views, $this->base_path );
 
 		$this->blade_compiler->never_expire_cache = $this->never_expire_cache;
 

--- a/inc/class-compiler.php
+++ b/inc/class-compiler.php
@@ -12,7 +12,6 @@
 namespace Travelopia\Blade;
 
 use ErrorException;
-use Illuminate\Support\Str;
 use Illuminate\View\Compilers\BladeCompiler;
 
 /**
@@ -25,34 +24,6 @@ class Compiler extends BladeCompiler {
 	 * @var bool Never expire cache.
 	 */
 	public bool $never_expire_cache = false;
-
-	/**
-	 * Get the path to the compiled version of a view.
-	 *
-	 * @param string $path Path to view.
-	 *
-	 * @return string
-	 */
-	public function getCompiledPath( $path ): string { // phpcs:ignore
-		// Get current working directory.
-		$cwd = getcwd();
-
-		// Handle case if the current working directory is /wp-admin and webroot is /wp.
-		// This scenario is common in local development environments.
-		if ( str_contains( $cwd, '/wp/wp-admin' ) ) {
-			$cwd = str_replace( '/wp/wp-admin', '', $cwd );
-		}
-
-		// Handle case if the current working directory is /wp-admin.
-		if ( str_contains( $cwd, '/wp-admin' ) ) {
-			$cwd = str_replace( '/wp-admin', '', $cwd );
-		}
-
-		// Get path.
-		$path = str_replace( $cwd, '', $path );
-
-		return $this->cachePath . '/' . sha1( 'v2' . Str::after( $path, $this->basePath ) ) . '.' . $this->compiledExtension; // phpcs:ignore
-	}
 
 	/**
 	 * Determine if the view at the given path is expired.

--- a/inc/class-compiler.php
+++ b/inc/class-compiler.php
@@ -34,8 +34,22 @@ class Compiler extends BladeCompiler {
 	 * @return string
 	 */
 	public function getCompiledPath( $path ): string { // phpcs:ignore
+		// Get current working directory.
+		$cwd = getcwd();
+
+		// Handle case if the current working directory is /wp-admin and webroot is /wp.
+		// This scenario is common in local development environments.
+		if ( str_contains( $cwd, '/wp/wp-admin' ) ) {
+			$cwd = str_replace( '/wp/wp-admin', '', $cwd );
+		}
+
+		// Handle case if the current working directory is /wp-admin.
+		if ( str_contains( $cwd, '/wp-admin' ) ) {
+			$cwd = str_replace( '/wp-admin', '', $cwd );
+		}
+
 		// Get path.
-		$path = str_replace( getcwd(), '', $path );
+		$path = str_replace( $cwd, '', $path );
 
 		return $this->cachePath . '/' . sha1( 'v2' . Str::after( $path, $this->basePath ) ) . '.' . $this->compiledExtension; // phpcs:ignore
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -79,6 +79,7 @@ function get_blade(): Blade {
 	$blade->paths_to_views         = apply_filters( 'wordpress_blade_view_paths', $blade_config['paths_to_views'] );
 	$blade->path_to_compiled_views = apply_filters( 'wordpress_blade_compiled_path', $blade_config['path_to_compiled_views'] );
 	$blade->never_expire_cache     = apply_filters( 'wordpress_blade_never_expire_cache', $blade_config['never_expire_cache'] );
+	$blade->base_path              = apply_filters( 'wordpress_blade_base_path', $blade_config['base_path'] );
 	$blade->view_callback          = __NAMESPACE__ . '\\view_callback';
 	$blade->initialize();
 


### PR DESCRIPTION
This PR handles an edge case when compiled blade views are accessed in `wp-admin`.