### PR TITLE
Use composer vendor binary for compile script

### DIFF
--- a/bin/wordpress-blade
+++ b/bin/wordpress-blade
@@ -15,7 +15,7 @@ use function Travelopia\Blade\get_configuration;
 // Get path to Blade config.
 $options              = getopt( 'c:v:', [ 'config-file:', 'vendor-autoload-file:' ] );
 $config_file          = $options['c'] ?? $options['config-file'] ?? '';
-$vendor_autoload_file = $options['v'] ?? $options['vendor-autoload-file'] ?? __DIR__ . '/../../../../vendor/autoload.php';
+$vendor_autoload_file = $options['v'] ?? $options['vendor-autoload-file'] ?? 'vendor/autoload.php';
 
 // Check if a config path was set.
 if ( empty( $config_file ) || ! file_exists( $config_file ) ) {
@@ -25,7 +25,7 @@ if ( empty( $config_file ) || ! file_exists( $config_file ) ) {
 
 // Check if vendor autoload file was set.
 if ( empty( $vendor_autoload_file ) || ! file_exists( $vendor_autoload_file ) ) {
-	echo "\033[31m✗ Path to config file missing!\n";
+	echo "\033[31m✗ Path to autoload file missing!\n";
 	exit( 1 );
 }
 

--- a/bin/wordpress-blade
+++ b/bin/wordpress-blade
@@ -1,3 +1,5 @@
+#!/usr/bin/env php
+
 <?php
 /**
  * Compile Blade Cache.
@@ -5,7 +7,10 @@
  * @package wordpress-blade
  */
 
-namespace Travelopia\Blade;
+use Travelopia\Blade\Blade;
+
+use function Travelopia\Blade\bootstrap;
+use function Travelopia\Blade\get_configuration;
 
 // Get path to Blade config.
 $options              = getopt( 'c:v:', [ 'config-file:', 'vendor-autoload-file:' ] );

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "homepage": "https://www.travelopia.com"
       }
     ],
+    "bin" : ["bin/wordpress-blade"],
     "require": {
         "illuminate/view": "^v10.48.20"
     },


### PR DESCRIPTION
Currently, we run the compile script using the following command:
```sh
php -d memory_limit=512M wp-content/mu-plugins/wordpress-blade/bin/compile.php --config-file=blade.config.php
```

As this is now a Composer package, the location of the compile executable could vary depending on the directory where the package is installed, making it difficult to determine the correct path. To simplify this, Composer manages vendor binaries by placing them in the `vendor/bin` directory, or another path specified by `config.bin-dir`. This pull request moves the compile binary to the `vendor/bin` directory, allowing it to be used with the following command:

```sh
# Using from composer scripts.
composer wordpress-blade -- --config-file=blade.config.php     
> wordpress-blade '--config-file=blade.config.php'

Compiling Blade cache...
✓ Blade cache compiled!

# Using from vendor with composer.
composer exec wordpress-blade -- --config-file=blade.config.php

Compiling Blade cache...
✓ Blade cache compiled!

# Running manually
./vendor/bin/wordpress-blade --config-file=blade.config.php    

Compiling Blade cache...
✓ Blade cache compiled!
```