### PR TITLE
WP-126 Register named_paths for identifying separate folders with prefix

### DIFF
--- a/inc/class-blade.php
+++ b/inc/class-blade.php
@@ -41,6 +41,13 @@ class Blade {
 	public array $paths_to_views = [];
 
 	/**
+	 * Store named paths for AnonymousComponentPaths.
+	 *
+	 * @var array Named paths for views.
+	 */
+	public array $named_paths = [];
+
+	/**
 	 * Store the path to the directory where all compiled views are cached.
 	 *
 	 * @var string Path to compiled views.

--- a/inc/class-blade.php
+++ b/inc/class-blade.php
@@ -41,13 +41,6 @@ class Blade {
 	public array $paths_to_views = [];
 
 	/**
-	 * Store named paths for AnonymousComponentPaths.
-	 *
-	 * @var array Named paths for views.
-	 */
-	public array $named_paths = [];
-
-	/**
 	 * Store the path to the directory where all compiled views are cached.
 	 *
 	 * @var string Path to compiled views.
@@ -138,8 +131,13 @@ class Blade {
 			} )::getFacadeAccessor()
 		);
 
-		// Register each named path as an anonymous component path.
-		foreach ( $this->named_paths as $prefix => $path ) {
+		// Register each path as an anonymous component path with its prefix.
+		foreach ( $this->paths_to_views as $prefix => $path ) {
+			// Skip paths without a prefix in the key.
+			if ( is_numeric( $prefix ) ) {
+				continue;
+			}
+
 			// Register the anonymous component path.
 			$this->blade_compiler->anonymousComponentPath( $path, $prefix );
 		}

--- a/inc/class-blade.php
+++ b/inc/class-blade.php
@@ -138,6 +138,12 @@ class Blade {
 			} )::getFacadeAccessor()
 		);
 
+		// Register each named path as an anonymous component path.
+		foreach ( $this->named_paths as $prefix => $path ) {
+			// Register the anonymous component path.
+			$this->blade_compiler->anonymousComponentPath( $path, $prefix );
+		}
+
 		// Callback function for every view.
 		if ( is_callable( $this->view_callback ) ) {
 			$this->view_factory->composer( '*' , function( $view ) {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -77,36 +77,15 @@ function get_blade(): Blade {
 	$blade_config                  = get_configuration();
 	$blade                         = new Blade();
 	$blade->paths_to_views         = apply_filters( 'wordpress_blade_view_paths', $blade_config['paths_to_views'] );
-	$blade->named_paths            = apply_filters( 'wordpress_blade_named_paths', $blade_config['named_paths'] );
+	$blade->named_paths            = apply_filters( 'wordpress_blade_named_paths', $blade_config['named_paths'] ?? [] );
 	$blade->path_to_compiled_views = apply_filters( 'wordpress_blade_compiled_path', $blade_config['path_to_compiled_views'] );
 	$blade->never_expire_cache     = apply_filters( 'wordpress_blade_never_expire_cache', $blade_config['never_expire_cache'] );
 	$blade->base_path              = apply_filters( 'wordpress_blade_base_path', $blade_config['base_path'] );
 	$blade->view_callback          = __NAMESPACE__ . '\\view_callback';
 	$blade->initialize();
 
-	// Register named_paths components.
-	register_component_namespaces( $blade );
-
 	// Return initialized Blade object.
 	return $blade;
-}
-
-/**
- * Register component namespaces with the Blade compiler.
- *
- * @param Blade $blade The Blade instance.
- *
- * @return void
- */
-function register_component_namespaces( Blade $blade = null ): void {
-	// Get the blade compiler.
-	$compiler = $blade->blade_compiler;
-
-	// Register each named path as an anonymous component path.
-	foreach ( $blade->named_paths as $prefix => $path ) {
-		// Register the anonymous component path.
-		$compiler->anonymousComponentPath( $path, $prefix );
-	}
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -104,11 +104,8 @@ function register_component_namespaces( Blade $blade = null ): void {
 
 	// Register each named path as an anonymous component path.
 	foreach ( $blade->named_paths as $prefix => $path ) {
-		// Create absolute paths.
-		$absolute_path = $blade->base_path . $path;
-
 		// Register the anonymous component path.
-		$compiler->anonymousComponentPath( $absolute_path, $prefix );
+		$compiler->anonymousComponentPath( $path, $prefix );
 	}
 }
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -77,14 +77,39 @@ function get_blade(): Blade {
 	$blade_config                  = get_configuration();
 	$blade                         = new Blade();
 	$blade->paths_to_views         = apply_filters( 'wordpress_blade_view_paths', $blade_config['paths_to_views'] );
+	$blade->named_paths            = apply_filters( 'wordpress_blade_named_paths', $blade_config['named_paths'] );
 	$blade->path_to_compiled_views = apply_filters( 'wordpress_blade_compiled_path', $blade_config['path_to_compiled_views'] );
 	$blade->never_expire_cache     = apply_filters( 'wordpress_blade_never_expire_cache', $blade_config['never_expire_cache'] );
 	$blade->base_path              = apply_filters( 'wordpress_blade_base_path', $blade_config['base_path'] );
 	$blade->view_callback          = __NAMESPACE__ . '\\view_callback';
 	$blade->initialize();
 
+	register_component_namespaces( $blade );
+
 	// Return initialized Blade object.
 	return $blade;
+}
+
+
+/**
+ * Register component namespaces with the Blade compiler.
+ *
+ * @param Blade $blade The Blade instance.
+ *
+ * @return void
+ */
+function register_component_namespaces( Blade $blade ): void {
+	// Get the blade compiler
+	$compiler = $blade->blade_compiler;
+
+	// Register each named path as an anonymous component path
+	foreach ( $blade->named_paths as $prefix => $path ) {
+		// Create absolute paths.
+		$absolute_path = $blade->base_path . $path;
+
+		// Register the anonymous component path
+		$compiler->anonymousComponentPath( $absolute_path, $prefix );
+	}
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -77,7 +77,6 @@ function get_blade(): Blade {
 	$blade_config                  = get_configuration();
 	$blade                         = new Blade();
 	$blade->paths_to_views         = apply_filters( 'wordpress_blade_view_paths', $blade_config['paths_to_views'] );
-	$blade->named_paths            = apply_filters( 'wordpress_blade_named_paths', $blade_config['named_paths'] ?? [] );
 	$blade->path_to_compiled_views = apply_filters( 'wordpress_blade_compiled_path', $blade_config['path_to_compiled_views'] );
 	$blade->never_expire_cache     = apply_filters( 'wordpress_blade_never_expire_cache', $blade_config['never_expire_cache'] );
 	$blade->base_path              = apply_filters( 'wordpress_blade_base_path', $blade_config['base_path'] );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -84,12 +84,12 @@ function get_blade(): Blade {
 	$blade->view_callback          = __NAMESPACE__ . '\\view_callback';
 	$blade->initialize();
 
+	// Register named_paths components.
 	register_component_namespaces( $blade );
 
 	// Return initialized Blade object.
 	return $blade;
 }
-
 
 /**
  * Register component namespaces with the Blade compiler.
@@ -98,16 +98,16 @@ function get_blade(): Blade {
  *
  * @return void
  */
-function register_component_namespaces( Blade $blade ): void {
-	// Get the blade compiler
+function register_component_namespaces( Blade $blade = null ): void {
+	// Get the blade compiler.
 	$compiler = $blade->blade_compiler;
 
-	// Register each named path as an anonymous component path
+	// Register each named path as an anonymous component path.
 	foreach ( $blade->named_paths as $prefix => $path ) {
 		// Create absolute paths.
 		$absolute_path = $blade->base_path . $path;
 
-		// Register the anonymous component path
+		// Register the anonymous component path.
 		$compiler->anonymousComponentPath( $absolute_path, $prefix );
 	}
 }


### PR DESCRIPTION
- Adds functionality to create [AnonymousComponentPath](https://laravel.com/docs/12.x/blade#anonymous-component-paths) in WordPress blade.
- Now you can add a prefix as a key and value as a path to our paths_to_views. These will be registered a anonymousComponentPath stating that we can use them as <x-{prefix}::{componentName}>
```
		'paths_to_views' => [
			'atoms' => '/wp-content/themes/enchanting/src/front-end/atoms'
		],
```
- This will create an anonymous component path with 'atoms' as prefix.
- If there is a component named button inside `atoms/` folder, it will became accessible using `<x-atoms::button>`