### PR TITLE
Disable double-encoding on Blade `{{ }}` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ define(
 		'never_expire_cache'     => false, // Use `true` on production environments.
 		'base_path'              => __DIR__, // The base path that is common to the front-end and admin.
 		'encode_echo'            => true, // Double-encode entities in `{{ }}` output. See "Echo encoding" below.
-		'register_wp_directives' => true, // Register `@text`, `@url`, `@attr`, `@safe_html` directives. See "WordPress-aware escape directives" below.
+		'register_wp_directives' => true, // Register `@escHtml`, `@escUrl`, `@escAttr`, `@wpKsesPost` directives. See "WordPress-aware escape directives" below.
 	]
 );
 ```
@@ -118,10 +118,12 @@ The package registers four Blade directives that wrap WordPress's escape helpers
 
 | Directive | Compiles to | Use for |
 |---|---|---|
-| `@text( $v )` | `echo esc_html( $v );` | Plain text in HTML bodies |
-| `@url( $v )` | `echo esc_url( $v );` | `href` / `src` attribute values |
-| `@attr( $v )` | `echo esc_attr( $v );` | Other HTML attribute values |
-| `@safe_html( $v )` | `echo wp_kses_post( $v );` | Rich text from editors (block content, ACF WYSIWYG, etc.) |
+| `@escHtml( $v )` | `echo esc_html( $v );` | Plain text in HTML bodies |
+| `@escUrl( $v )` | `echo esc_url( $v );` | `href` / `src` attribute values |
+| `@escAttr( $v )` | `echo esc_attr( $v );` | Other HTML attribute values |
+| `@wpKsesPost( $v )` | `echo wp_kses_post( $v );` | Rich text from editors (block content, ACF WYSIWYG, etc.) |
+
+Directive names are prefixed (`@esc*` / `@wp*`) so they correlate with the underlying WordPress helper and stay out of Laravel's reserved-directive namespace.
 
 The expression — including its surrounding parentheses — is forwarded verbatim to the underlying WordPress helper. To skip registration (for example, if your project registers its own escape directives), set `'register_wp_directives' => false` in the bootstrap config or filter `wordpress_blade_register_wp_directives`.
 

--- a/README.md
+++ b/README.md
@@ -100,9 +100,16 @@ define(
 		'path_to_compiled_views' => __DIR__ . '/wp-content/themes/<your-theme>/dist/blade', // Where you want Blade to save compiled files.
 		'never_expire_cache'     => false, // Use `true` on production environments.
 		'base_path'              => __DIR__, // The base path that is common to the front-end and admin.
+		'encode_echo'            => true, // Double-encode entities in `{{ }}` output. See "Echo encoding" below.
 	]
 );
 ```
+
+#### Echo encoding
+
+By default Blade's `{{ $value }}` calls `e( $value, true )`, which **double-encodes** HTML entities. This is the Laravel default and is preserved by setting `encode_echo => true`.
+
+If your templates receive values that have already been escaped upstream (for example, the output of WordPress's `esc_html()`, `esc_attr()`, or `wptexturize()`), double-encoding turns `&amp;` into the literal text `&amp;amp;`. Set `encode_echo => false` to switch to single-encoding (`e( $value, false )`) so upstream encoding is preserved.
 
 ### Bootstrap a layout.
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ define(
 		'never_expire_cache'     => false, // Use `true` on production environments.
 		'base_path'              => __DIR__, // The base path that is common to the front-end and admin.
 		'encode_echo'            => true, // Double-encode entities in `{{ }}` output. See "Echo encoding" below.
+		'register_wp_directives' => true, // Register `@text`, `@url`, `@attr`, `@safe_html` directives. See "WordPress-aware escape directives" below.
 	]
 );
 ```
@@ -110,6 +111,19 @@ define(
 By default Blade's `{{ $value }}` calls `e( $value, true )`, which **double-encodes** HTML entities. This is the Laravel default and is preserved by setting `encode_echo => true`.
 
 If your templates receive values that have already been escaped upstream (for example, the output of WordPress's `esc_html()`, `esc_attr()`, or `wptexturize()`), double-encoding turns `&amp;` into the literal text `&amp;amp;`. Set `encode_echo => false` to switch to single-encoding (`e( $value, false )`) so upstream encoding is preserved.
+
+#### WordPress-aware escape directives
+
+The package registers four Blade directives that wrap WordPress's escape helpers, letting templates express intent rather than the function call:
+
+| Directive | Compiles to | Use for |
+|---|---|---|
+| `@text( $v )` | `echo esc_html( $v );` | Plain text in HTML bodies |
+| `@url( $v )` | `echo esc_url( $v );` | `href` / `src` attribute values |
+| `@attr( $v )` | `echo esc_attr( $v );` | Other HTML attribute values |
+| `@safe_html( $v )` | `echo wp_kses_post( $v );` | Rich text from editors (block content, ACF WYSIWYG, etc.) |
+
+The expression — including its surrounding parentheses — is forwarded verbatim to the underlying WordPress helper. To skip registration (for example, if your project registers its own escape directives), set `'register_wp_directives' => false` in the bootstrap config or filter `wordpress_blade_register_wp_directives`.
 
 ### Bootstrap a layout.
 

--- a/inc/class-blade.php
+++ b/inc/class-blade.php
@@ -66,6 +66,22 @@ class Blade {
 	public bool $encode_echo = true;
 
 	/**
+	 * Whether to register WordPress-aware escape directives on the Blade compiler.
+	 *
+	 * When `true`, the following directives are available in templates:
+	 *
+	 * - `@text($v)`      → `echo esc_html( $v );`
+	 * - `@url($v)`       → `echo esc_url( $v );`
+	 * - `@attr($v)`      → `echo esc_attr( $v );`
+	 * - `@safe_html($v)` → `echo wp_kses_post( $v );`
+	 *
+	 * Set to `false` to skip registration (e.g. if the consumer registers its own).
+	 *
+	 * @var bool Register WP directives.
+	 */
+	public bool $register_wp_directives = true;
+
+	/**
 	 * Store view factory.
 	 *
 	 * @var ViewFactory View factory.
@@ -123,6 +139,13 @@ class Blade {
 			$this->blade_compiler->setEchoFormat( 'e(%s, false)' );
 		}
 
+		// Register WordPress-aware escape directives so consumers can write
+		// `@text($v)`, `@url($v)`, `@attr($v)`, and `@safe_html($v)` instead of
+		// the corresponding `esc_*()` / `wp_kses_post()` calls inline.
+		if ( $this->register_wp_directives ) {
+			$this->register_wordpress_directives();
+		}
+
 		$view_resolver->register( 'blade', function () {
 			return new CompilerEngine( $this->blade_compiler );
 		} );
@@ -169,6 +192,36 @@ class Blade {
 			} );
 		}
 		// phpcs:enable
+	}
+
+	/**
+	 * Register WordPress-aware escape directives on the Blade compiler.
+	 *
+	 * The directive expression — including the surrounding parentheses — is
+	 * forwarded verbatim to the corresponding WordPress escape helper, so
+	 * `@url( $foo )` compiles to `<?php echo esc_url( $foo ); ?>`.
+	 *
+	 * @return void
+	 */
+	protected function register_wordpress_directives(): void {
+		$directives = [
+			'text'      => function ( string $expression ): string {
+				return "<?php echo esc_html{$expression}; ?>";
+			},
+			'url'       => function ( string $expression ): string {
+				return "<?php echo esc_url{$expression}; ?>";
+			},
+			'attr'      => function ( string $expression ): string {
+				return "<?php echo esc_attr{$expression}; ?>";
+			},
+			'safe_html' => function ( string $expression ): string {
+				return "<?php echo wp_kses_post{$expression}; ?>";
+			},
+		];
+
+		foreach ( $directives as $name => $compiler ) {
+			$this->blade_compiler->directive( $name, $compiler );
+		}
 	}
 
 	/**

--- a/inc/class-blade.php
+++ b/inc/class-blade.php
@@ -104,6 +104,13 @@ class Blade {
 
 		$this->blade_compiler->never_expire_cache = $this->never_expire_cache;
 
+		// Disable double-encoding on `{{ }}` output. WordPress's `esc_*()` helpers
+		// already encode special characters upstream of the template, so leaving Blade's
+		// default `e( $value, true )` in place re-encodes them — `&amp;` becomes the
+		// literal text `&amp;amp;`. Calling `setEchoFormat()` with the explicit `false`
+		// flag preserves the upstream encoding.
+		$this->blade_compiler->setEchoFormat( 'e(%s, false)' );
+
 		$view_resolver->register( 'blade', function () {
 			return new CompilerEngine( $this->blade_compiler );
 		} );

--- a/inc/class-blade.php
+++ b/inc/class-blade.php
@@ -70,10 +70,10 @@ class Blade {
 	 *
 	 * When `true`, the following directives are available in templates:
 	 *
-	 * - `@text($v)`      → `echo esc_html( $v );`
-	 * - `@url($v)`       → `echo esc_url( $v );`
-	 * - `@attr($v)`      → `echo esc_attr( $v );`
-	 * - `@safe_html($v)` → `echo wp_kses_post( $v );`
+	 * - `@escHtml($v)`     → `echo esc_html( $v );`
+	 * - `@escUrl($v)`      → `echo esc_url( $v );`
+	 * - `@escAttr($v)`     → `echo esc_attr( $v );`
+	 * - `@wpKsesPost($v)`  → `echo wp_kses_post( $v );`
 	 *
 	 * Set to `false` to skip registration (e.g. if the consumer registers its own).
 	 *
@@ -140,8 +140,8 @@ class Blade {
 		}
 
 		// Register WordPress-aware escape directives so consumers can write
-		// `@text($v)`, `@url($v)`, `@attr($v)`, and `@safe_html($v)` instead of
-		// the corresponding `esc_*()` / `wp_kses_post()` calls inline.
+		// `@escHtml($v)`, `@escUrl($v)`, `@escAttr($v)`, and `@wpKsesPost($v)` instead
+		// of the corresponding `esc_*()` / `wp_kses_post()` calls inline.
 		if ( $this->register_wp_directives ) {
 			$this->register_wordpress_directives();
 		}
@@ -197,24 +197,26 @@ class Blade {
 	/**
 	 * Register WordPress-aware escape directives on the Blade compiler.
 	 *
-	 * The directive expression — including the surrounding parentheses — is
-	 * forwarded verbatim to the corresponding WordPress escape helper, so
-	 * `@url( $foo )` compiles to `<?php echo esc_url( $foo ); ?>`.
+	 * Directive names are prefixed (`@escHtml`, `@escUrl`, `@escAttr`,
+	 * `@wpKsesPost`) so they correlate with the underlying WordPress helper
+	 * and stay out of Laravel's reserved-directive namespace. The directive
+	 * expression — including the surrounding parentheses — is forwarded
+	 * verbatim, so `@escUrl( $foo )` compiles to `<?php echo esc_url( $foo ); ?>`.
 	 *
 	 * @return void
 	 */
 	protected function register_wordpress_directives(): void {
 		$directives = [
-			'text'      => function ( string $expression ): string {
+			'escHtml'    => function ( string $expression ): string {
 				return "<?php echo esc_html{$expression}; ?>";
 			},
-			'url'       => function ( string $expression ): string {
+			'escUrl'     => function ( string $expression ): string {
 				return "<?php echo esc_url{$expression}; ?>";
 			},
-			'attr'      => function ( string $expression ): string {
+			'escAttr'    => function ( string $expression ): string {
 				return "<?php echo esc_attr{$expression}; ?>";
 			},
-			'safe_html' => function ( string $expression ): string {
+			'wpKsesPost' => function ( string $expression ): string {
 				return "<?php echo wp_kses_post{$expression}; ?>";
 			},
 		];

--- a/inc/class-blade.php
+++ b/inc/class-blade.php
@@ -55,6 +55,17 @@ class Blade {
 	public string $base_path = '';
 
 	/**
+	 * Whether to double-encode entities in `{{ }}` output.
+	 *
+	 * `true` preserves Blade's default `e( $value, true )` (double-encoding).
+	 * `false` switches to `e( $value, false )` so already-escaped strings
+	 * (e.g. output of WordPress `esc_*()` helpers) are not re-encoded.
+	 *
+	 * @var bool Encode echo.
+	 */
+	public bool $encode_echo = true;
+
+	/**
 	 * Store view factory.
 	 *
 	 * @var ViewFactory View factory.
@@ -104,12 +115,13 @@ class Blade {
 
 		$this->blade_compiler->never_expire_cache = $this->never_expire_cache;
 
-		// Disable double-encoding on `{{ }}` output. WordPress's `esc_*()` helpers
-		// already encode special characters upstream of the template, so leaving Blade's
-		// default `e( $value, true )` in place re-encodes them — `&amp;` becomes the
-		// literal text `&amp;amp;`. Calling `setEchoFormat()` with the explicit `false`
-		// flag preserves the upstream encoding.
-		$this->blade_compiler->setEchoFormat( 'e(%s, false)' );
+		// Optionally disable double-encoding on `{{ }}` output. WordPress's `esc_*()`
+		// helpers already encode special characters upstream of the template, so Blade's
+		// default `e( $value, true )` re-encodes them — `&amp;` becomes the literal text
+		// `&amp;amp;`. Sites can opt in to single-encoding via the `encode_echo` config.
+		if ( ! $this->encode_echo ) {
+			$this->blade_compiler->setEchoFormat( 'e(%s, false)' );
+		}
 
 		$view_resolver->register( 'blade', function () {
 			return new CompilerEngine( $this->blade_compiler );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -30,6 +30,7 @@ function bootstrap(): void {
  *     path_to_compiled_views: string,
  *     never_expire_cache: bool,
  *     encode_echo: bool,
+ *     register_wp_directives: bool,
  * }
  */
 function get_configuration(): array {
@@ -39,6 +40,7 @@ function get_configuration(): array {
 		'path_to_compiled_views' => '',
 		'never_expire_cache'     => false,
 		'encode_echo'            => true,
+		'register_wp_directives' => true,
 	];
 
 	// Initialize Blade.
@@ -83,6 +85,7 @@ function get_blade(): Blade {
 	$blade->never_expire_cache     = apply_filters( 'wordpress_blade_never_expire_cache', $blade_config['never_expire_cache'] );
 	$blade->base_path              = apply_filters( 'wordpress_blade_base_path', $blade_config['base_path'] );
 	$blade->encode_echo            = apply_filters( 'wordpress_blade_encode_echo', $blade_config['encode_echo'] );
+	$blade->register_wp_directives = apply_filters( 'wordpress_blade_register_wp_directives', $blade_config['register_wp_directives'] );
 	$blade->view_callback          = __NAMESPACE__ . '\\view_callback';
 	$blade->initialize();
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -29,6 +29,7 @@ function bootstrap(): void {
  *     path_to_views: string,
  *     path_to_compiled_views: string,
  *     never_expire_cache: bool,
+ *     encode_echo: bool,
  * }
  */
 function get_configuration(): array {
@@ -37,6 +38,7 @@ function get_configuration(): array {
 		'paths_to_views'         => [],
 		'path_to_compiled_views' => '',
 		'never_expire_cache'     => false,
+		'encode_echo'            => true,
 	];
 
 	// Initialize Blade.
@@ -80,6 +82,7 @@ function get_blade(): Blade {
 	$blade->path_to_compiled_views = apply_filters( 'wordpress_blade_compiled_path', $blade_config['path_to_compiled_views'] );
 	$blade->never_expire_cache     = apply_filters( 'wordpress_blade_never_expire_cache', $blade_config['never_expire_cache'] );
 	$blade->base_path              = apply_filters( 'wordpress_blade_base_path', $blade_config['base_path'] );
+	$blade->encode_echo            = apply_filters( 'wordpress_blade_encode_echo', $blade_config['encode_echo'] );
 	$blade->view_callback          = __NAMESPACE__ . '\\view_callback';
 	$blade->initialize();
 


### PR DESCRIPTION
## Summary

Two changes to make this package WordPress-aware out of the box:

1. **Single-encode echo output** — adds an `encode_echo` config key (default `true`, preserving Blade's existing double-encoding). When set to `false`, `Blade::initialize()` calls `setEchoFormat( 'e(%s, false)' )` so `{{ $value }}` invokes `htmlspecialchars( $value, ENT_QUOTES, 'UTF-8', false )` instead of the Laravel default of `true`.

2. **WordPress-aware escape directives** — registers four Blade directives on the compiler (default on; opt out via `register_wp_directives => false`):

   | Directive | Compiles to |
   |---|---|
   | `@text( $v )` | `echo esc_html( $v );` |
   | `@url( $v )` | `echo esc_url( $v );` |
   | `@attr( $v )` | `echo esc_attr( $v );` |
   | `@safe_html( $v )` | `echo wp_kses_post( $v );` |

   The directive expression — including its surrounding parentheses — is forwarded verbatim to the underlying WP helper.

## Why

WordPress consumers of this package routinely pass already-escaped strings (output of `esc_html()`, `esc_attr()`, `wptexturize()`, etc.) into templates. Blade's default double-encoding then re-encodes those entities:

- `&amp;` becomes the literal text `&amp;amp;`
- Non-breaking spaces become `&amp;nbsp;`
- WP-filtered curly quotes / em-dashes get further mangled

Single-encoding fixes that and matches what WordPress's own escaping helpers already do.

Shipping the directives alongside the flag closes the second half of the gap: consumers no longer have to scatter `{{ esc_url($v) }}` / `{!! wp_kses_post($v) !!}` across templates. The WP function lives in one audited place in the package. This is the package-level directive vocabulary discussed in review.

Together these unblock the site-side cleanup tracked in [EEWEB-735](https://tuispecialist.atlassian.net/browse/EEWEB-735) — sites can collapse defensive `<x-escape :content="$var" />` wrappers into `@text( $var )` (and `@url` / `@attr` / `@safe_html` as appropriate).

## Risk

- `encode_echo` defaults to `true` — existing consumers see no behavior change unless they opt in. Single-encoding preserves Blade's safety property (HTML-special characters are still encoded); only already-encoded entities are no longer re-encoded.
- `register_wp_directives` defaults to `true` — additive only. None of the four directive names collide with Laravel built-ins or anything in Illuminate View. Consumers that register a same-named directive after `get_blade()` still take precedence (last-write-wins).
- Either or both can be opted out via the config keys above or matching `wordpress_blade_encode_echo` / `wordpress_blade_register_wp_directives` filters.
- Consumers running with `never_expire_cache => true` on production must invalidate compiled Blade views when flipping `encode_echo` — `setEchoFormat` is applied at compile time.

## Test plan

- [x] PHPCS clean.
- [x] Syntax-checked locally (`php -l`).
- [ ] Spot-check on Europe Express: render a string containing `&`, `<`, and a UTF-8 entity (e.g. `&nbsp;`) through `{{ $var }}` with `encode_echo => false`; confirm output matches `esc_html` upstream.
- [ ] Spot-check on Europe Express: render `@text($v)` / `@url($v)` / `@attr($v)` / `@safe_html($v)` in a Blade template; inspect the compiled view to confirm each calls the expected WP helper.
- [ ] Spot-check on Europe Express: set `register_wp_directives => false`; confirm the four directives are no longer registered.
- [ ] Repo CI: `tests.yml` workflow runs on this PR.

> Note: the package has no PHPUnit scaffold (`tests.yml` runs PHPCS only). Adding a unit-test harness is its own piece of work — this PR documents the verification it does have honestly rather than implying full coverage.

[EEWEB-735]: https://tuispecialist.atlassian.net/browse/EEWEB-735