### PR TITLE
Fix directive callbacks to wrap expression in parens

### DIFF
--- a/inc/class-blade.php
+++ b/inc/class-blade.php
@@ -199,25 +199,26 @@ class Blade {
 	 *
 	 * Directive names are prefixed (`@escHtml`, `@escUrl`, `@escAttr`,
 	 * `@wpKsesPost`) so they correlate with the underlying WordPress helper
-	 * and stay out of Laravel's reserved-directive namespace. The directive
-	 * expression — including the surrounding parentheses — is forwarded
-	 * verbatim, so `@escUrl( $foo )` compiles to `<?php echo esc_url( $foo ); ?>`.
+	 * and stay out of Laravel's reserved-directive namespace. Illuminate's
+	 * Blade compiler strips the outer parentheses before invoking the
+	 * directive callback, so each callback wraps the expression in `(...)`
+	 * — `@escUrl( $foo )` compiles to `<?php echo esc_url( $foo ); ?>`.
 	 *
 	 * @return void
 	 */
 	protected function register_wordpress_directives(): void {
 		$directives = [
 			'escHtml'    => function ( string $expression ): string {
-				return "<?php echo esc_html{$expression}; ?>";
+				return "<?php echo esc_html({$expression}); ?>";
 			},
 			'escUrl'     => function ( string $expression ): string {
-				return "<?php echo esc_url{$expression}; ?>";
+				return "<?php echo esc_url({$expression}); ?>";
 			},
 			'escAttr'    => function ( string $expression ): string {
-				return "<?php echo esc_attr{$expression}; ?>";
+				return "<?php echo esc_attr({$expression}); ?>";
 			},
 			'wpKsesPost' => function ( string $expression ): string {
-				return "<?php echo wp_kses_post{$expression}; ?>";
+				return "<?php echo wp_kses_post({$expression}); ?>";
 			},
 		];
 


### PR DESCRIPTION
## Summary

The four WP-aware directives introduced in #10 (`@escHtml`, `@escUrl`, `@escAttr`, `@wpKsesPost`) compile to invalid PHP. Illuminate's `BladeCompiler::callCustomDirective()` strips the surrounding parentheses from the directive expression before invoking the callback, so the existing callback string `"<?php echo esc_html{$expression}; ?>"` produces `<?php echo esc_html$foo; ?>` — function name immediately followed by `$variable`, syntax error. Confirmed by `php -l` on compiled output of any `@escHtml($foo)` template.

Fix wraps the expression in `(...)` inside each callback. Docblock updated to make Illuminate's paren-stripping behaviour explicit so the next contributor doesn't fall into the same trap.

Scope intentionally minimal — code fix + docblock only. A test scaffold for the package is a separate conversation; will file a follow-up ticket so the maintainers can decide testing posture on its own merits rather than via a hotfix PR.

## Jira

https://tuispecialist.atlassian.net/browse/EEWEB-735

## Test plan

- [ ] CI green — `composer lint` passes.
- [ ] In an EE checkout pointed at this branch: `npm run build:php` produces `dist/blade/*.php` where `@escHtml($var)` resolves to `<?php echo esc_html($var); ?>`, and `php -l` passes on every compiled file.
- [ ] Locally: temporarily revert the four-line paren fix in `inc/class-blade.php` and re-run the EE build — confirms compiled output reverts to invalid PHP (`esc_html$var`), establishing the regression direction.

## Follow-up

After merge, tag `1.2.1` so EE can bump and ship the variable-form `<x-escape>` → `@escHtml(...)` sweep currently blocked on this fix.