### PR TITLE
EEWEB-735: Forward config in CLI bootstrap; add @stripText directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ define(
 		'never_expire_cache'     => false, // Use `true` on production environments.
 		'base_path'              => __DIR__, // The base path that is common to the front-end and admin.
 		'encode_echo'            => true, // Double-encode entities in `{{ }}` output. See "Echo encoding" below.
-		'register_wp_directives' => true, // Register `@escHtml`, `@escUrl`, `@escAttr`, `@wpKsesPost` directives. See "WordPress-aware escape directives" below.
+		'register_wp_directives' => true, // Register `@escHtml`, `@escUrl`, `@escAttr`, `@wpKsesPost`, `@stripText` directives. See "WordPress-aware escape directives" below.
 	]
 );
 ```
@@ -114,7 +114,7 @@ If your templates receive values that have already been escaped upstream (for ex
 
 #### WordPress-aware escape directives
 
-The package registers four Blade directives that wrap WordPress's escape helpers, letting templates express intent rather than the function call:
+The package registers five Blade directives that wrap WordPress's escape helpers, letting templates express intent rather than the function call:
 
 | Directive | Compiles to | Use for |
 |---|---|---|
@@ -122,8 +122,9 @@ The package registers four Blade directives that wrap WordPress's escape helpers
 | `@escUrl( $v )` | `echo esc_url( $v );` | `href` / `src` attribute values |
 | `@escAttr( $v )` | `echo esc_attr( $v );` | Other HTML attribute values |
 | `@wpKsesPost( $v )` | `echo wp_kses_post( $v );` | Rich text from editors (block content, ACF WYSIWYG, etc.) |
+| `@stripText( $v )` | `echo esc_html( wp_strip_all_tags( $v ) );` | Plain-text fields that may receive `wpautop`-wrapped or otherwise tag-laden content (post titles via filters, ACF text fields rendered alongside WYSIWYG siblings). Strip first, then escape. |
 
-Directive names are prefixed (`@esc*` / `@wp*`) so they correlate with the underlying WordPress helper and stay out of Laravel's reserved-directive namespace.
+Directive names are prefixed (`@esc*` / `@wp*` / `@stripText`) so they correlate with the underlying WordPress helper and stay out of Laravel's reserved-directive namespace.
 
 The expression — including its surrounding parentheses — is forwarded verbatim to the underlying WordPress helper. To skip registration (for example, if your project registers its own escape directives), set `'register_wp_directives' => false` in the bootstrap config or filter `wordpress_blade_register_wp_directives`.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ define(
 		'never_expire_cache'     => false, // Use `true` on production environments.
 		'base_path'              => __DIR__, // The base path that is common to the front-end and admin.
 		'encode_echo'            => true, // Double-encode entities in `{{ }}` output. See "Echo encoding" below.
-		'register_wp_directives' => true, // Register `@escHtml`, `@escUrl`, `@escAttr`, `@wpKsesPost`, `@stripText` directives. See "WordPress-aware escape directives" below.
+		'register_wp_directives' => true, // Register `@escHtml`, `@escUrl`, `@escAttr`, `@wpKsesPost`, `@stripTags`, `@safeEscape` directives. See "WordPress-aware escape directives" below.
 	]
 );
 ```
@@ -114,7 +114,7 @@ If your templates receive values that have already been escaped upstream (for ex
 
 #### WordPress-aware escape directives
 
-The package registers five Blade directives that wrap WordPress's escape helpers, letting templates express intent rather than the function call:
+The package registers six Blade directives that wrap WordPress's escape helpers, letting templates express intent rather than the function call:
 
 | Directive | Compiles to | Use for |
 |---|---|---|
@@ -122,9 +122,10 @@ The package registers five Blade directives that wrap WordPress's escape helpers
 | `@escUrl( $v )` | `echo esc_url( $v );` | `href` / `src` attribute values |
 | `@escAttr( $v )` | `echo esc_attr( $v );` | Other HTML attribute values |
 | `@wpKsesPost( $v )` | `echo wp_kses_post( $v );` | Rich text from editors (block content, ACF WYSIWYG, etc.) |
-| `@stripText( $v )` | `echo esc_html( wp_strip_all_tags( $v ) );` | Plain-text fields that may receive `wpautop`-wrapped or otherwise tag-laden content (post titles via filters, ACF text fields rendered alongside WYSIWYG siblings). Strip first, then escape. |
+| `@stripTags( $v )` | `echo wp_strip_all_tags( $v );` | Atomic strip-only — for values that need tag removal but will be escaped or used somewhere else (JSON, plain text response, an upstream-escaped pipeline). |
+| `@safeEscape( $v )` | `echo esc_html( wp_strip_all_tags( $v ) );` | The combined "strip then escape" path — the safe default for plain-text fields that may receive `wpautop`-wrapped or otherwise tag-laden content (post titles via filters, ACF text fields rendered alongside WYSIWYG siblings). |
 
-Directive names are prefixed (`@esc*` / `@wp*` / `@stripText`) so they correlate with the underlying WordPress helper and stay out of Laravel's reserved-directive namespace.
+Directive names are prefixed / cased to correlate with the underlying WordPress helper (`@esc*` → `esc_*()`, `@wp*` → `wp_*()`, `@stripTags` → `wp_strip_all_tags()`, `@safeEscape` → the combined safe-default) and stay out of Laravel's reserved-directive namespace.
 
 The expression — including its surrounding parentheses — is forwarded verbatim to the underlying WordPress helper. To skip registration (for example, if your project registers its own escape directives), set `'register_wp_directives' => false` in the bootstrap config or filter `wordpress_blade_register_wp_directives`.
 

--- a/bin/wordpress-blade
+++ b/bin/wordpress-blade
@@ -43,6 +43,8 @@ $blade                         = new Blade();
 $blade->paths_to_views         = $blade_config['paths_to_views'] ?? [];
 $blade->path_to_compiled_views = $blade_config['path_to_compiled_views'] ?? '';
 $blade->base_path              = $blade_config['base_path'] ?? '';
+$blade->encode_echo            = $blade_config['encode_echo'] ?? true;
+$blade->register_wp_directives = $blade_config['register_wp_directives'] ?? true;
 $blade->initialize();
 
 // Build Blade cache.

--- a/inc/class-blade.php
+++ b/inc/class-blade.php
@@ -74,6 +74,7 @@ class Blade {
 	 * - `@escUrl($v)`      → `echo esc_url( $v );`
 	 * - `@escAttr($v)`     → `echo esc_attr( $v );`
 	 * - `@wpKsesPost($v)`  → `echo wp_kses_post( $v );`
+	 * - `@stripText($v)`   → `echo esc_html( wp_strip_all_tags( $v ) );`
 	 *
 	 * Set to `false` to skip registration (e.g. if the consumer registers its own).
 	 *
@@ -219,6 +220,9 @@ class Blade {
 			},
 			'wpKsesPost' => function ( string $expression ): string {
 				return "<?php echo wp_kses_post({$expression}); ?>";
+			},
+			'stripText'  => function ( string $expression ): string {
+				return "<?php echo esc_html( wp_strip_all_tags({$expression}) ); ?>";
 			},
 		];
 

--- a/inc/class-blade.php
+++ b/inc/class-blade.php
@@ -74,7 +74,8 @@ class Blade {
 	 * - `@escUrl($v)`      → `echo esc_url( $v );`
 	 * - `@escAttr($v)`     → `echo esc_attr( $v );`
 	 * - `@wpKsesPost($v)`  → `echo wp_kses_post( $v );`
-	 * - `@stripText($v)`   → `echo esc_html( wp_strip_all_tags( $v ) );`
+	 * - `@stripTags($v)`   → `echo wp_strip_all_tags( $v );`
+	 * - `@safeEscape($v)`  → `echo esc_html( wp_strip_all_tags( $v ) );` (combined: strip then escape)
 	 *
 	 * Set to `false` to skip registration (e.g. if the consumer registers its own).
 	 *
@@ -221,7 +222,10 @@ class Blade {
 			'wpKsesPost' => function ( string $expression ): string {
 				return "<?php echo wp_kses_post({$expression}); ?>";
 			},
-			'stripText'  => function ( string $expression ): string {
+			'stripTags'  => function ( string $expression ): string {
+				return "<?php echo wp_strip_all_tags({$expression}); ?>";
+			},
+			'safeEscape' => function ( string $expression ): string {
 				return "<?php echo esc_html( wp_strip_all_tags({$expression}) ); ?>";
 			},
 		];

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Use Laravel Blade components in WordPress.
  * Author: Travelopia Team
  * Author URI: https://www.travelopia.com
- * Version: 1.2.1
+ * Version: 1.2.2
  *
  * @package wordpress-blade
  */


### PR DESCRIPTION
## Summary

Two related fixes building on PR #10 (`encode_echo` + four `@esc*` / `@wpKsesPost` directives), surfaced while wiring the EE consumer.

### 1. CLI bootstrap forwards `encode_echo` and `register_wp_directives`

`bin/wordpress-blade` reads the full config via `get_configuration()` but only assigned `paths_to_views`, `path_to_compiled_views`, and `base_path` to the `Blade` instance before calling `initialize()`. The two new config keys from PR #10 were dropped on the floor, so the CLI-built compiled cache used class defaults (`encode_echo=true`, `register_wp_directives=true`) regardless of consumer config.

The WP runtime path (`inc/namespace.php::get_blade()`) was already forwarding them via `apply_filters` — only the CLI was lying. This commit brings the CLI in line, using `?? true` defaults to mirror the class defaults (the CLI is not a hookable environment, so no `apply_filters` wrapping).

Surfaced on Europe Express: runtime worked, `npm run build:php` produced cache files with the wrong `setEchoFormat`.

### 2. New `@stripText` directive

Adds a fifth WP-aware directive: `@stripText( $v )` → `echo esc_html( wp_strip_all_tags( $v ) );`.

This is the missing 1:1 replacement for the `<x-escape>` component shipped by every brand theme since the package was created. `<x-escape>`'s default branch did exactly this pair (strip tags, then escape as text). When EE migrated variable-form `<x-escape>` callers to `@escHtml` per PR #10's design, WYSIWYG-wrapped content (post titles via filters, ACF wysiwyg fields, special-offer descriptions) surfaced literal `<p>` and `</p>` tags in the rendered output — `@escHtml` doesn't strip them, the original `<x-escape>` did.

With `@stripText`, the variable-form migration becomes a safe bulk substitution rather than per-call classification. Consumers can later tighten specific callers to `@escHtml` once they audit which variables are guaranteed never to carry HTML wrappers; that's strict-tightening and reversible.

Both changes registered under the existing `register_wp_directives` flag / `wordpress_blade_register_wp_directives` filter — no new opt-in surface.

Jira: [EEWEB-735](https://tuispecialist.atlassian.net/browse/EEWEB-735)

## Test plan

- [ ] PHPCS clean (`vendor/bin/phpcs`).
- [ ] Locally consume the branch from the EE project via composer `path` repository (or VCS branch); `npm run build:php` in the EE checkout.
- [ ] Compiled views in EE `dist/blade/`:
  - [ ] `{{ \$x }}` callers compile to `e(\$x, false)` (not `e(\$x)`).
  - [ ] `@escHtml(\$x)` compiles to `echo esc_html(\$x);`.
  - [ ] `@stripText(\$x)` compiles to `echo esc_html( wp_strip_all_tags(\$x) );`.
- [ ] EE pages render correctly — Featured Itineraries cards (descriptions, no literal `<p>`), Single Sightseeing (titles, no `&#038;`), quote forms (FIT / Elevated Journeys / Group), Blog cards.
- [ ] `register_wp_directives => false` in EE config still skips registration of all five directives.

[EEWEB-735]: https://tuispecialist.atlassian.net/browse/EEWEB-735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ